### PR TITLE
fix(listbox+combobox): render options panel outside of scrollable container AL-4547

### DIFF
--- a/src/components/Combobox.vue
+++ b/src/components/Combobox.vue
@@ -99,6 +99,13 @@ export default defineComponent({
     inline: {
       type: Boolean,
       default: false
+    },
+    /**
+     * allow the options panel to be rendered outside the flow of a container that has content that needs scrolling
+     */
+    escapeOverflow: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['update:modelValue', 'update:query'],
@@ -110,6 +117,9 @@ export default defineComponent({
     const query = ref('')
 
     const inputRef = ref()
+
+    const comboboxButton = ref()
+    const optionsPanelWidth = computed(() => comboboxButton.value?.el.offsetWidth)
 
     const selectInputValue = () => {
       if (inputRef.value) {
@@ -224,16 +234,19 @@ export default defineComponent({
       singleModelValueColor,
       isInputFocused,
       placeholderString,
-      handleDelete
+      handleDelete,
+      comboboxButton,
+      optionsPanelWidth
     }
   }
 })
 </script>
 <template>
-  <Combobox v-model="model" as="div" class="relative" :multiple="isMultiSelect">
+  <Combobox v-model="model" as="div" :class="{ 'relative': !escapeOverflow }" :multiple="isMultiSelect">
     <!-- @slot  named `#input` slot. Requires ComboboxInput component from headless-ui to work, and optionally ComboboxButton. Slot props: `query<string>`, calculated `displayValue<string>`, and `updateQuery<(value:string)=>void>` callback to be used with text input v-model update event-->
     <slot name="input" :query="query" :display-value="displayValue" :update-query="updateQuery">
       <ComboboxButton
+        ref="comboboxButton"
         as="div"
         class="group a-text-input-base relative flex items-center py-0"
         :class="[
@@ -298,7 +311,9 @@ export default defineComponent({
       :class="panelClasses"
       :direction="direction"
       :multi="isMultiSelect"
-      :inline="inline">
+      :inline="inline"
+      :escape-overflow="escapeOverflow"
+      :width="optionsPanelWidth">
       <template #default>
         <!-- @slot  `#default` slot. Takes `a-option` or `a-option-group` components without any wrappers. Use this slot to render options with extra styles or markup. Default value: `options` prop rendered as `a-option`s or `a-option-group`s -->
         <slot :filtered-options="filteredOptions"></slot>

--- a/src/components/Listbox.vue
+++ b/src/components/Listbox.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { defineComponent, PropType } from 'vue'
+import { defineComponent, PropType, ref, computed } from 'vue'
 import { Listbox, ListboxButton } from '@headlessui/vue'
 
 import type { Option } from './Option.vue'
@@ -79,10 +79,20 @@ export default defineComponent({
     inline: {
       type: Boolean,
       default: false
+    },
+    /**
+     * allow the options panel to be rendered outside the flow of a container that has content that needs scrolling
+     */
+    escapeOverflow: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['update:modelValue'],
   setup() {
+    const listboxButton = ref()
+    const optionsPanelWidth = computed(() => listboxButton.value?.el.offsetWidth)
+
     // hack together a tab-out behavior for the listbox
     const handleTab = (event: KeyboardEvent) => {
       if (event.key === 'Tab') {
@@ -91,7 +101,7 @@ export default defineComponent({
       }
     }
 
-    return { handleTab }
+    return { handleTab, listboxButton, optionsPanelWidth }
   },
   computed: {
     flatOptions() {
@@ -117,8 +127,9 @@ export default defineComponent({
 })
 </script>
 <template>
-  <Listbox v-model="model" as="div" class="group relative">
+  <Listbox v-model="model" as="div" class="group" :class="{ 'relative': !escapeOverflow }">
     <ListboxButton
+      ref="listboxButton"
       class="a-text-input flex items-center group-focus-within:a-text-input-focus"
       :class="[
         size === 'md' ? 'a-text-input--md' : 'a-text-input--sm',
@@ -152,6 +163,8 @@ export default defineComponent({
       :class="panelClasses"
       :direction="direction"
       :inline="inline"
+      :escape-overflow="escapeOverflow"
+      :width="optionsPanelWidth"
       @keyup="handleTab">
       <slot></slot>
     </OptionsPanel>

--- a/src/components/internal/OptionsPanel.vue
+++ b/src/components/internal/OptionsPanel.vue
@@ -58,6 +58,20 @@ export default defineComponent({
     inline: {
       type: Boolean,
       default: false
+    },
+    /**
+     * allow the options panel to be rendered outside the flow of a container that has content that needs scrolling
+     */
+    escapeOverflow: {
+      type: Boolean,
+      default: false
+    },
+    /**
+     * width of the panel in pixels, to be provided when escapeOverflow is true
+     */
+    width: {
+      type: Number,
+      default: 0
     }
   },
   setup() {
@@ -75,11 +89,15 @@ export default defineComponent({
       {
         'bottom-full': direction === 'up',
         'my-1': size === 'md' && !inline,
-        'mt-[3px] mb-1': size === 'sm' && !inline
-      },
-      size === 'sm' ? 'body-sm' : 'body-md',
-      inline ? 'mt-2 w-unset' : ' a-panel-sm absolute left-0 z-10 min-w-full max-w-full py-2'
-    ]">
+        'mt-[3px] mb-1': size === 'sm' && !inline,
+        'body-sm': size === 'sm',
+        'body-md': size === 'md',
+        'mt-2 w-unset': inline && !escapeOverflow,
+        'a-panel-sm absolute z-10 py-2': !inline && escapeOverflow,
+        'a-panel-sm absolute left-0 z-10 min-w-full max-w-full py-2': !inline && !escapeOverflow
+      }
+    ]"
+    :style="escapeOverflow && width && `width: ${width}px`">
     <!-- @slot  `#default` slot. Takes `a-option` or `a-option-group` components without any wrappers. Use this slot to render options with extra styles or markup. Default value: `options` prop rendered as `a-option`s or `a-option-group`s -->
     <slot>
       <template v-if="areOptionsGrouped(options)">

--- a/src/stories/Combobox.mdx
+++ b/src/stories/Combobox.mdx
@@ -315,3 +315,17 @@ via `panelClasses` prop. Remember to add `overflow-auto` along with your height 
 <Canvas>
   <Story id="components-combobox--panel-classes" />
 </Canvas>
+
+### Inside a container with overflow-auto
+
+Set the `escapeOverflow` prop to `true` to render the options panel outside the flow of the container.
+A typical use case would be a Combobox inside a Dialog.
+
+```html
+<a-combobox escape-overflow … />
+```
+
+<Canvas>
+  <Story id="components-combobox--overflow-container" />
+</Canvas>
+

--- a/src/stories/Combobox.stories.ts
+++ b/src/stories/Combobox.stories.ts
@@ -822,3 +822,18 @@ MultiselectOptionsWithColorSelected.args = {
   initValue: []
 }
 MultiselectOptionsWithColorSelected.play = selectOption
+
+const TemplateOverflow: StoryFn = () => ({
+  components: { ACombobox },
+  template: `
+    <div class="relative h-[15rem]">
+      <div class="border border-sanfran h-16 overflow-auto w-[20rem] flex flex-col px-2">
+        <div class="text-sanfran">Overflow container</div>
+        <ACombobox escape-overflow class="flex-1" model-value="" :options="[{ value: 0, label: 'Graphic' }, { value: 1, label: 'Rendered' }, { value: 2, label: 'Black and white' }]" />
+      </div>
+    </div>`
+})
+
+export const OverflowContainer = TemplateOverflow.bind({})
+OverflowContainer.play = openCombobox
+

--- a/src/stories/Dialog.stories.mdx
+++ b/src/stories/Dialog.stories.mdx
@@ -234,19 +234,6 @@ An example with a long title that wraps onto the next line.
   </Story>
 </Canvas>
 
-### Listbox inside dialog
-
-<Canvas>
-  <Story
-    name="listbox inside dialog"
-    args={{
-      title: '3D drawing style',
-      slots: `<template #body><AListbox model-value="" :options="[{ value: 0, label: 'Graphic' }, { value: 1, label: 'Rendered' }, { value: 2, label: 'Black and white' }]" /></template>`
-    }}>
-    {Template.bind({})}
-  </Story>
-</Canvas>
-
 ### Left-aligned action
 
 Example of an extra action that is aligned to the left and is not a button.

--- a/src/stories/Listbox.mdx
+++ b/src/stories/Listbox.mdx
@@ -230,3 +230,16 @@ via `panelClasses` prop. Remember to add `overflow-auto` along with your height 
 <Canvas>
   <Story id="components-listbox--panel-classes" />
 </Canvas>
+
+### Inside a container with overflow-auto
+
+Set the `escapeOverflow` prop to `true` to render the options panel outside the flow of the container.
+A typical use case would be a Listbox inside a Dialog.
+
+```html
+<a-listbox escape-overflow … />
+```
+
+<Canvas>
+  <Story id="components-listbox--overflow-container" />
+</Canvas>

--- a/src/stories/Listbox.stories.ts
+++ b/src/stories/Listbox.stories.ts
@@ -377,3 +377,17 @@ OptionsWithColorSelected.args = {
   initValue: 'test'
 }
 OptionsWithColorSelected.play = openListbox
+
+const TemplateOverflow: StoryFn = () => ({
+  components: { AListbox },
+  template: `
+    <div class="relative h-[15rem]">
+      <div class="border border-sanfran h-16 overflow-auto w-[20rem] flex flex-col px-2">
+        <div class="text-sanfran">Overflow container</div>
+        <AListbox escape-overflow class="flex-1" :options="[{ value: 0, label: 'Graphic' }, { value: 1, label: 'Rendered' }, { value: 2, label: 'Black and white' }]" />
+      </div>
+    </div>`
+})
+
+export const OverflowContainer = TemplateOverflow.bind({})
+OverflowContainer.play = openListbox


### PR DESCRIPTION
Fix feels a bit dirty, I don't like to do styling via JavaScript…

![Screenshot 2023-07-14 at 09 32 10](https://github.com/archilogic-com/honeycomb/assets/89903103/744bbf52-f662-42df-b82a-3893e9699f70)
