### PR TITLE
fix(types): include json files in declaration + rename color type

### DIFF
--- a/src/colors/index.ts
+++ b/src/colors/index.ts
@@ -1,5 +1,5 @@
 import colorMap from './colorMap.json'
 
-export type Colors = keyof typeof colorMap
+export type Color = keyof typeof colorMap
 
 export { colorMap }

--- a/src/components/ColorCircle.vue
+++ b/src/components/ColorCircle.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
-import { type Colors, colorMap } from '../colors'
+import { type Color, colorMap } from '../colors'
 
 export default defineComponent({
   name: 'AColorCircle',
@@ -9,11 +9,11 @@ export default defineComponent({
      * fill color of the circle
      */
     color: {
-      type: String as PropType<Colors>,
+      type: String as PropType<Color>,
       default: ''
     },
     borderColor: {
-      type: String as PropType<Colors>,
+      type: String as PropType<Color>,
       default: ''
     },
     /**

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -3,13 +3,13 @@ import { computed, defineComponent, PropType } from 'vue'
 import { ListboxOption, ComboboxOption } from '@headlessui/vue'
 import ACheckbox from './Checkbox.vue'
 import AColorCircle from './ColorCircle.vue'
-import { type Colors } from '../colors'
+import { type Color } from '../colors'
 
 export type Option = {
   value: string
   label: string
   disabled?: boolean
-  color?: Colors
+  color?: Color
 }
 
 export default defineComponent({

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -2,7 +2,7 @@
 import { defineComponent, computed, PropType } from 'vue'
 import AIcon from './Icon.vue'
 import AColorCircle from './ColorCircle.vue'
-import type { Colors } from '../colors'
+import type { Color } from '../colors'
 
 export default defineComponent({
   name: 'ATag',
@@ -27,7 +27,7 @@ export default defineComponent({
      * produces an optional color circle
      */
     color: {
-      type: String as PropType<Colors>,
+      type: String as PropType<Color>,
       default: ''
     },
     /**

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "src/**/*.stories.ts", "src/**/*.test.ts"],
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.stories.ts", "src/**/*.test.ts"],
   "compilerOptions": {
     "rootDir": "src"
   }


### PR DESCRIPTION
The `Colors` type export was previously broken. Including JSON assets when generating the declaration fixes the issue. Since it wasn't exposed yet I took the opportunity to rename it to `Color` singular