### PR TITLE
fix(types): don't rely on tsconfig.json#paths in declaration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as Components from '@/components'
+import * as Components from './components'
 import type { App } from 'vue'
 
 export function registerAllComponents(app: App): void {
@@ -7,8 +7,8 @@ export function registerAllComponents(app: App): void {
   })
 }
 
-export * from '@/components'
+export * from './components'
 
-export * from '@/composables'
+export * from './composables'
 
-export * from '@/colors'
+export * from './colors'

--- a/src/stories/Combobox.stories.ts
+++ b/src/stories/Combobox.stories.ts
@@ -3,7 +3,7 @@ import { Meta, StoryFn } from '@storybook/vue3'
 import { ACombobox, AOption, AOptionGroup, AColorCircle } from '../components'
 import { within, userEvent } from '@storybook/testing-library'
 import ComboboxDocs from './Combobox.mdx'
-import type { Option } from '@/components/Option.vue'
+import type { Option } from '../components/Option.vue'
 
 export default {
   title: 'Components/Combobox',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "isolatedModules": true,
     "types": ["vite/client", "vitest/globals", "mdx"],
     "baseUrl": ".",
-    "paths": { "@/*": ["./src/*"] },
     "skipLibCheck": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,


### PR DESCRIPTION
The type declaration is broken, because a consumer doesn't know how to resolve `@/...`. Since the alias was only used in a few places, the simplest thing seems to be to remove it.