### PR TITLE
fix(combobox): clear query on blur

### DIFF
--- a/src/components/Combobox.vue
+++ b/src/components/Combobox.vue
@@ -177,7 +177,6 @@ export default defineComponent({
         ? query.value
         : getOption(modelValue)?.label || query.value || modelValue
     }
-    const isInputFocused = ref(false)
 
     const placeholderString = computed(() =>
       isMultiSelect(model.value) && model.value.length && !props.inline ? '' : props.placeholder
@@ -197,6 +196,11 @@ export default defineComponent({
         query.value = value || ''
         emit('update:query', query.value)
       }
+    }
+
+    const clearQuery = () => {
+      query.value = ''
+      emit('update:query', query.value)
     }
 
     const removeValue = (value: string, event: Event) => {
@@ -232,11 +236,11 @@ export default defineComponent({
       inputRef,
       selectInputValue,
       singleModelValueColor,
-      isInputFocused,
       placeholderString,
       handleDelete,
       comboboxButton,
-      optionsPanelWidth
+      optionsPanelWidth,
+      clearQuery
     }
   }
 })
@@ -298,8 +302,7 @@ export default defineComponent({
             :display-value="value => displayValue(value as string | string[])"
             :placeholder="placeholderString"
             :disabled="$attrs.disabled"
-            @focus="isInputFocused = true"
-            @blur="isInputFocused = false"
+            @blur="clearQuery"
             @change.stop="updateQuery($event.target.value)" />
         </div>
         <FloatingArrow

--- a/src/stories/Combobox.stories.ts
+++ b/src/stories/Combobox.stories.ts
@@ -42,6 +42,15 @@ const typeIntoCombobox = async (
   await userEvent.type(canvas.getByRole('combobox'), query)
 }
 
+const typeIntoComboboxAndBlur = async (
+  { canvasElement }: { canvasElement: HTMLElement },
+  query = 'no'
+) => {
+  const canvas = within(canvasElement)
+  await userEvent.type(canvas.getByRole('combobox'), query)
+  await userEvent.click(canvasElement)
+}
+
 const selectOptionAndTypeIntoCombobox = async (
   { canvasElement }: { canvasElement: HTMLElement },
   query = 'top'
@@ -100,6 +109,10 @@ export const NoResults = Template.bind({})
 NoResults.args = { placeholder: 'Pick a position' }
 NoResults.play = args => typeIntoCombobox(args, 'nope')
 
+export const QueryClearedOnBlur = Template.bind({})
+QueryClearedOnBlur.args = { placeholder: 'Pick a position' }
+QueryClearedOnBlur.play = typeIntoComboboxAndBlur
+
 export const Multiselect = Template.bind({})
 Multiselect.args = {
   classes: 'w-[200px]',
@@ -125,6 +138,10 @@ MultiselectSelectedRemove.play = removeOption
 export const MultiselectNoResults = Template.bind({})
 MultiselectNoResults.args = { initValue: [], classes: 'w-[200px]' }
 MultiselectNoResults.play = args => selectOptionAndTypeIntoCombobox(args, 'nope')
+
+export const MultiselectQueryClearedOnBlur = Template.bind({})
+MultiselectQueryClearedOnBlur.args = { initValue: [], classes: 'w-[200px]' }
+MultiselectQueryClearedOnBlur.play = typeIntoComboboxAndBlur
 
 export const SizeMdSelected = Template.bind({})
 SizeMdSelected.args = {


### PR DESCRIPTION
I noticed that a typed in query could be left in a blurred combobox, giving the impression that it's the combobox value.
