### PR TITLE
feat(switcher): add component Al 1713

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,7 @@
 import type { StorybookConfig } from '@storybook/vue3-vite'
 
 const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
+  stories: ['../src/stories/*.mdx', '../src/stories/*.stories.@(js|jsx|ts|tsx)'],
 
   addons: ['@storybook/addon-links', '@storybook/addon-essentials'],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "vite-plugin-dts": "3.6.0",
         "vite-svg-loader": "^4.0.0",
         "vitest": "^0.34.6",
+        "vue-component-type-helpers": "^1.8.22",
         "vue-tsc": "^1.8.22"
       },
       "engines": {
@@ -23282,9 +23283,9 @@
       }
     },
     "node_modules/vue-component-type-helpers": {
-      "version": "1.8.20",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.20.tgz",
-      "integrity": "sha512-eaAOlvn+mkv9jX54w9BDdM8/kLhh5FFFGB9niuypE6StBGKSBA8/XbkbsVIfaBnRdFtdVxD2BC/PmWlpWl+WvA==",
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.22.tgz",
+      "integrity": "sha512-LK3wJHs3vJxHG292C8cnsRusgyC5SEZDCzDCD01mdE/AoREFMl2tzLRuzwyuEsOIz13tqgBcnvysN3Lxsa14Fw==",
       "dev": true
     },
     "node_modules/vue-docgen-api": {
@@ -40209,9 +40210,9 @@
       }
     },
     "vue-component-type-helpers": {
-      "version": "1.8.20",
-      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.20.tgz",
-      "integrity": "sha512-eaAOlvn+mkv9jX54w9BDdM8/kLhh5FFFGB9niuypE6StBGKSBA8/XbkbsVIfaBnRdFtdVxD2BC/PmWlpWl+WvA==",
+      "version": "1.8.22",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.22.tgz",
+      "integrity": "sha512-LK3wJHs3vJxHG292C8cnsRusgyC5SEZDCzDCD01mdE/AoREFMl2tzLRuzwyuEsOIz13tqgBcnvysN3Lxsa14Fw==",
       "dev": true
     },
     "vue-docgen-api": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "vite-plugin-dts": "3.6.0",
     "vite-svg-loader": "^4.0.0",
     "vitest": "^0.34.6",
+    "vue-component-type-helpers": "^1.8.22",
     "vue-tsc": "^1.8.22"
   },
   "prettier": "@archilogic/prettier"

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -10,10 +10,6 @@ export default defineComponent({
     RadioGroupOption
   },
   props: {
-    label: {
-      type: String,
-      default: ''
-    },
     modelValue: {
       type: String,
       required: true
@@ -21,6 +17,14 @@ export default defineComponent({
     options: {
       type: Array as PropType<{ label: string; value: string }[]>,
       required: true
+    },
+    label: {
+      type: String,
+      default: ''
+    },
+    raised: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['update:modelValue'],
@@ -40,7 +44,10 @@ export default defineComponent({
 })
 </script>
 <template>
-  <RadioGroup v-model="model" class="p-1 rounded bg-whisper flex max-w-fit gap-1">
+  <RadioGroup
+    v-model="model"
+    class="p-1 rounded bg-whisper flex max-w-fit gap-1"
+    :class="{ 'shadow-sm': raised }">
     <RadioGroupLabel class="sr-only">{{ label }}</RadioGroupLabel>
     <RadioGroupOption
       v-for="option in options"

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -71,10 +71,11 @@ export default defineComponent({
       :disabled="option.disabled || disabled"
       class="focus-visible:focus-outline flex h-8 rounded transition-colors duration-500 ease-out cursor-pointer">
       <div
-        class="flex items-center px-3 py-1 rounded active:bg-zurich48 active:text-mediumblue"
+        class="flex items-center px-3 py-1 rounded"
         :class="{
           'text-mediumblue bg-zurich': checked,
-          'hover:bg-gray active:bg-zurich48': !checked && !option.disabled && !disabled,
+          'hover:bg-gray hover:text-navy active:bg-zurich48 active:text-mediumblue':
+            !option.disabled && !disabled,
           'opacity-40 cursor-not-allowed': option.disabled || disabled
         }"
         :aria-label="option.icon ? option.label : undefined"

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -1,13 +1,22 @@
 <script lang="ts">
 import { defineComponent, computed, PropType } from 'vue'
 import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue'
+import AIcon from './Icon.vue'
+
+export type SwitcherOption = {
+  label: string
+  value: string
+  disabled?: boolean
+  icon?: string
+}
 
 export default defineComponent({
   name: 'ASwitcher',
   components: {
     RadioGroup,
     RadioGroupLabel,
-    RadioGroupOption
+    RadioGroupOption,
+    AIcon
   },
   props: {
     modelValue: {
@@ -15,7 +24,7 @@ export default defineComponent({
       required: true
     },
     options: {
-      type: Array as PropType<{ label: string; value: string; disabled?: boolean }[]>,
+      type: Array as PropType<SwitcherOption[]>,
       required: true
     },
     label: {
@@ -50,8 +59,8 @@ export default defineComponent({
 <template>
   <RadioGroup
     v-model="model"
-    class="p-1 rounded bg-whisper flex max-w-fit gap-1 cursor-pointer"
-    :class="{ 'shadow-sm': raised, 'opacity-40 cursor-not-allowed': disabled }"
+    class="p-[2px] rounded bg-whisper flex max-w-fit gap-1"
+    :class="{ 'shadow-sm': raised }"
     :disabled="disabled">
     <RadioGroupLabel class="sr-only">{{ label }}</RadioGroupLabel>
     <RadioGroupOption
@@ -59,16 +68,22 @@ export default defineComponent({
       :key="option.value"
       v-slot="{ checked }"
       :value="option.value"
-      :disabled="option.disabled"
-      class="focus-visible:focus-outline flex rounded transition-colors duration-500 ease-out">
+      :disabled="option.disabled || disabled"
+      class="focus-visible:focus-outline flex h-8 rounded transition-colors duration-500 ease-out">
       <div
-        class="flex px-3 py-1 rounded active:bg-zurich48 active:text-mediumblue"
+        class="flex items-center px-3 py-1 rounded enabled:active:bg-zurich48 enabled:active:text-mediumblue enabled:cursor-pointer"
         :class="{
           'text-mediumblue bg-zurich': checked,
-          'hover:bg-gray': !checked,
-          'opacity-40 cursor-not-allowed': option.disabled
-        }">
-        {{ option.label }}
+          'hover:bg-gray': !checked && !option.disabled && !disabled,
+          'opacity-40 cursor-not-allowed': option.disabled || disabled
+        }"
+        :aria-label="option.icon ? option.label : undefined">
+        <slot :name="option.value">
+          <a-icon v-if="option.icon" :name="option.icon" size="sm"></a-icon>
+          <template v-else>
+            {{ option.label }}
+          </template>
+        </slot>
       </div>
     </RadioGroupOption>
   </RadioGroup>

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -69,15 +69,16 @@ export default defineComponent({
       v-slot="{ checked }"
       :value="option.value"
       :disabled="option.disabled || disabled"
-      class="focus-visible:focus-outline flex h-8 rounded transition-colors duration-500 ease-out">
+      class="focus-visible:focus-outline flex h-8 rounded transition-colors duration-500 ease-out cursor-pointer">
       <div
-        class="flex items-center px-3 py-1 rounded enabled:active:bg-zurich48 enabled:active:text-mediumblue enabled:cursor-pointer"
+        class="flex items-center px-3 py-1 rounded active:bg-zurich48 active:text-mediumblue"
         :class="{
           'text-mediumblue bg-zurich': checked,
-          'hover:bg-gray': !checked && !option.disabled && !disabled,
+          'hover:bg-gray active:bg-zurich48': !checked && !option.disabled && !disabled,
           'opacity-40 cursor-not-allowed': option.disabled || disabled
         }"
-        :aria-label="option.icon ? option.label : undefined">
+        :aria-label="option.icon ? option.label : undefined"
+        :title="option.icon ? option.label : undefined">
         <slot :name="option.value">
           <a-icon v-if="option.icon" :name="option.icon" size="sm"></a-icon>
           <template v-else>

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -1,0 +1,61 @@
+<script lang="ts">
+import { defineComponent, computed, PropType } from 'vue'
+import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue'
+
+export default defineComponent({
+  name: 'ASwitcher',
+  components: {
+    RadioGroup,
+    RadioGroupLabel,
+    RadioGroupOption
+  },
+  props: {
+    label: {
+      type: String,
+      default: ''
+    },
+    modelValue: {
+      type: String,
+      required: true
+    },
+    options: {
+      type: Array as PropType<{ label: string; value: string }[]>,
+      required: true
+    }
+  },
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    const model = computed({
+      get: () => {
+        return props.modelValue
+      },
+      set: value => {
+        emit('update:modelValue', value)
+      }
+    })
+    return {
+      model
+    }
+  }
+})
+</script>
+<template>
+  <RadioGroup v-model="model" class="p-1 rounded bg-whisper flex max-w-fit gap-1">
+    <RadioGroupLabel class="sr-only">{{ label }}</RadioGroupLabel>
+    <RadioGroupOption
+      v-for="option in options"
+      :key="option.value"
+      v-slot="{ checked }"
+      :value="option.value"
+      class="focus-visible:focus-outline flex rounded cursor-pointer transition-colors duration-500 ease-out">
+      <div
+        class="flex px-3 py-1 rounded active:bg-zurich48 active:text-mediumblue"
+        :class="{
+          'text-mediumblue bg-zurich': checked,
+          'hover:bg-athens': !checked
+        }">
+        {{ option.label }}
+      </div>
+    </RadioGroupOption>
+  </RadioGroup>
+</template>

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -15,7 +15,7 @@ export default defineComponent({
       required: true
     },
     options: {
-      type: Array as PropType<{ label: string; value: string }[]>,
+      type: Array as PropType<{ label: string; value: string; disabled?: boolean }[]>,
       required: true
     },
     label: {
@@ -23,6 +23,10 @@ export default defineComponent({
       default: ''
     },
     raised: {
+      type: Boolean,
+      default: false
+    },
+    disabled: {
       type: Boolean,
       default: false
     }
@@ -46,20 +50,23 @@ export default defineComponent({
 <template>
   <RadioGroup
     v-model="model"
-    class="p-1 rounded bg-whisper flex max-w-fit gap-1"
-    :class="{ 'shadow-sm': raised }">
+    class="p-1 rounded bg-whisper flex max-w-fit gap-1 cursor-pointer"
+    :class="{ 'shadow-sm': raised, 'opacity-40 cursor-not-allowed': disabled }"
+    :disabled="disabled">
     <RadioGroupLabel class="sr-only">{{ label }}</RadioGroupLabel>
     <RadioGroupOption
       v-for="option in options"
       :key="option.value"
       v-slot="{ checked }"
       :value="option.value"
-      class="focus-visible:focus-outline flex rounded cursor-pointer transition-colors duration-500 ease-out">
+      :disabled="option.disabled"
+      class="focus-visible:focus-outline flex rounded transition-colors duration-500 ease-out">
       <div
         class="flex px-3 py-1 rounded active:bg-zurich48 active:text-mediumblue"
         :class="{
           'text-mediumblue bg-zurich': checked,
-          'hover:bg-athens': !checked
+          'hover:bg-gray': !checked,
+          'opacity-40 cursor-not-allowed': option.disabled
         }">
         {{ option.label }}
       </div>

--- a/src/stories/Combobox.mdx
+++ b/src/stories/Combobox.mdx
@@ -1,5 +1,9 @@
-import { Story, ArgsTable, Canvas } from '@storybook/addon-docs'
+import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs'
 import { ACombobox } from '../components'
+
+import * as ComboboxStories from './Combobox.stories'
+
+<Meta of={ComboboxStories} />
 
 # Combobox
 

--- a/src/stories/Combobox.stories.ts
+++ b/src/stories/Combobox.stories.ts
@@ -2,18 +2,12 @@ import { ref, computed, Ref } from 'vue'
 import { Meta, StoryFn } from '@storybook/vue3'
 import { ACombobox, AOption, AOptionGroup, AColorCircle } from '../components'
 import { within, userEvent } from '@storybook/testing-library'
-import ComboboxDocs from './Combobox.mdx'
 import type { Option } from '../components/Option.vue'
 
 export default {
   title: 'Components/Combobox',
   component: ACombobox,
-  subcomponents: { AOption, AOptionGroup },
-  parameters: {
-    docs: {
-      page: ComboboxDocs
-    }
-  }
+  subcomponents: { AOption, AOptionGroup }
 } as Meta
 
 const focusCombobox: StoryFn['play'] = async ({ canvasElement }) => {

--- a/src/stories/Listbox.mdx
+++ b/src/stories/Listbox.mdx
@@ -1,5 +1,9 @@
-import { Story, ArgsTable, Canvas } from '@storybook/addon-docs'
+import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs'
 import { AListbox } from '../components'
+
+import * as ListboxStories from './Listbox.stories'
+
+<Meta of={ListboxStories} />
 
 # Listbox
 

--- a/src/stories/Listbox.stories.ts
+++ b/src/stories/Listbox.stories.ts
@@ -2,17 +2,11 @@ import { ref, computed } from 'vue'
 import { Meta, StoryFn } from '@storybook/vue3'
 import { within, userEvent } from '@storybook/testing-library'
 import { AListbox, AOption, AOptionGroup } from '../components'
-import ListboxDocs from './Listbox.mdx'
 
 export default {
   title: 'Components/Listbox',
   component: AListbox,
-  subcomponents: { AOption, AOptionGroup },
-  parameters: {
-    docs: {
-      page: ListboxDocs
-    }
-  }
+  subcomponents: { AOption, AOptionGroup }
 } as Meta
 
 const defaultOptions = [

--- a/src/stories/NumberInput.mdx
+++ b/src/stories/NumberInput.mdx
@@ -1,7 +1,9 @@
-import { Story, ArgsTable, Canvas } from '@storybook/addon-docs'
-import { ref } from 'vue'
-import { ANumberInput } from '../components'
+import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs'
 import AInput from '../components/internal/Input.vue'
+
+import * as NumberInputStories from './NumberInput.stories'
+
+<Meta of={NumberInputStories} />
 
 # Number Input
 

--- a/src/stories/NumberInput.stories.ts
+++ b/src/stories/NumberInput.stories.ts
@@ -2,16 +2,10 @@ import { ref } from 'vue'
 import { Meta, StoryFn } from '@storybook/vue3'
 import { within, userEvent } from '@storybook/testing-library'
 import { ANumberInput, AInputGroup } from '../components'
-import NumberInputDocs from './NumberInput.mdx'
 
 export default {
   title: 'Components/NumberInput',
-  component: ANumberInput,
-  parameters: {
-    docs: {
-      page: NumberInputDocs
-    }
-  }
+  component: ANumberInput
 } as Meta
 
 const Template: StoryFn = (args, meta) => ({

--- a/src/stories/RadioInput.mdx
+++ b/src/stories/RadioInput.mdx
@@ -1,6 +1,8 @@
 import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs'
-import { ref, computed } from 'vue'
 import { ARadioInput } from '../components'
+import * as RadioInputStories from './RadioInput.stories'
+
+<Meta of={RadioInputStories} />
 
 # RadioInput
 

--- a/src/stories/RadioInput.stories.ts
+++ b/src/stories/RadioInput.stories.ts
@@ -2,16 +2,10 @@ import { ref } from 'vue'
 import { Meta, StoryFn } from '@storybook/vue3'
 import { within, userEvent } from '@storybook/testing-library'
 import { ARadioInput } from '../components'
-import RadioInputDocs from './RadioInput.mdx'
 
 export default {
   title: 'Components/RadioInput',
-  component: ARadioInput,
-  parameters: {
-    docs: {
-      page: RadioInputDocs
-    }
-  }
+  component: ARadioInput
 } as Meta
 
 const Template: StoryFn = args => ({

--- a/src/stories/Switcher.stories.ts
+++ b/src/stories/Switcher.stories.ts
@@ -120,6 +120,9 @@ export const IconOptions: Story = {
  * option slots can be used.
  * The switcher component exposes a dynamic slot for each option
  * generated with the option's value as the slot's name.
+ *
+ * For information on template syntax for dynamic slot names, see
+ * [official vue documentation](https://vuejs.org/guide/components/slots.html#dynamic-slot-names).
  */
 export const UsingSlots: Story = {
   render: args => ({

--- a/src/stories/Switcher.stories.ts
+++ b/src/stories/Switcher.stories.ts
@@ -5,6 +5,15 @@ import type { ComponentProps } from 'vue-component-type-helpers'
 import ASwitcher from '../components/Switcher.vue'
 import AIcon from '../components/Icon.vue'
 
+/**
+ *
+ * The `<a-switcher>` component is a wrapper around
+ * [Headless UI's Radio Group components](https://headlessui.com/vue/radio-group).
+ *
+ * ```html
+ * <a-switcher label="Units" :options="unitList" v-model="selectedUnits"/>
+ * ```
+ */
 const meta: Meta<typeof ASwitcher> = {
   component: ASwitcher,
   title: 'Components/Switcher',
@@ -32,6 +41,9 @@ const renderSwitcher = (args: SwitcherProps) => ({
       <ASwitcher v-model="selected" v-bind="args" />`
 })
 
+/**
+ * The switcher component requires a list of `options`, a `v-model` value, and a `label` string for accessible label of the component as a whole.
+ */
 export const Primary: Story = {
   render: renderSwitcher,
   args: {
@@ -43,6 +55,10 @@ export const Primary: Story = {
   }
 }
 
+/**
+ * The Switcher component can display several options,
+ * but in most cases for selection between more than three options we recommend considering a different component, e.g. Listbox or Combobox.
+ */
 export const ThreeOptions: Story = {
   render: renderSwitcher,
   args: {
@@ -54,6 +70,10 @@ export const ThreeOptions: Story = {
     label: 'View'
   }
 }
+
+/**
+ * One of the options can be disabled by passing a disabled property on the relevant option object.
+ */
 export const DisabledOption: Story = {
   render: renderSwitcher,
   args: {
@@ -66,6 +86,9 @@ export const DisabledOption: Story = {
   }
 }
 
+/**
+ * Or you can disable the whole component by setting the `disabled` prop on `<a-switcher>`.
+ */
 export const DisabledSwitcher: Story = {
   render: renderSwitcher,
   args: {
@@ -74,6 +97,13 @@ export const DisabledSwitcher: Story = {
   }
 }
 
+/**
+ * If the options have an icon property,
+ * the value of the label property will be passed to the option's `aria-label` attribute,
+ * and the icon displayed to the user.
+ *
+ * **Note**: only icons of size "sm" are currently supported.
+ */
 export const IconOptions: Story = {
   render: renderSwitcher,
   args: {
@@ -85,6 +115,12 @@ export const IconOptions: Story = {
   }
 }
 
+/**
+ * For arbitrary content, such as icon + text label, unsupported icons, or customized style
+ * option slots can be used.
+ * The switcher component exposes a dynamic slot for each option
+ * generated with the option's value as the slot's name.
+ */
 export const UsingSlots: Story = {
   render: args => ({
     components: { ASwitcher, AIcon },
@@ -107,6 +143,9 @@ export const UsingSlots: Story = {
   }
 }
 
+/**
+ * For an elevated appearance (with box-shadow), set the `raised` prop on `<a-switcher>`.
+ */
 export const RaisedSwitcher: Story = {
   render: renderSwitcher,
   args: {

--- a/src/stories/Switcher.stories.ts
+++ b/src/stories/Switcher.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/vue3'
+import { ref } from 'vue'
+
+import ASwitcher from '../components/Switcher.vue'
+
+const meta: Meta<typeof ASwitcher> = {
+  component: ASwitcher,
+  title: 'Components/Switcher'
+}
+
+export default meta
+
+type Story = StoryObj<typeof ASwitcher>
+
+export const Primary: Story = {
+  render: () => ({
+    components: { ASwitcher },
+    setup() {
+      const options = [
+        { label: 'metric', value: 'm' },
+        { label: 'imperial', value: 'i' }
+      ]
+      const selected = ref('m')
+      const updateValue = (newValue: string) => {
+        selected.value = newValue
+      }
+      return { selected, options, updateValue }
+    },
+    template: `<div class="p-4 bg-white">
+        <ASwitcher :model-value="selected" :options="options" label="Units" @update:modelValue="updateValue" />
+      </div>`
+  })
+}

--- a/src/stories/Switcher.stories.ts
+++ b/src/stories/Switcher.stories.ts
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/vue3'
 import { ref } from 'vue'
+import type { ComponentProps } from 'vue-component-type-helpers'
 
 import ASwitcher from '../components/Switcher.vue'
+import AIcon from '../components/Icon.vue'
 
 const meta: Meta<typeof ASwitcher> = {
   component: ASwitcher,
@@ -17,19 +19,98 @@ export default meta
 
 type Story = StoryObj<typeof ASwitcher>
 
-export const Primary: Story = {
-  render: () => ({
-    components: { ASwitcher },
-    setup() {
-      const options = [
-        { label: 'metric', value: 'm' },
-        { label: 'imperial', value: 'i' }
-      ]
-      const selected = ref('m')
+type SwitcherProps = ComponentProps<typeof ASwitcher>
 
-      return { selected, options }
+const renderSwitcher = (args: SwitcherProps) => ({
+  components: { ASwitcher },
+  setup() {
+    const selected = ref(args.options[0].value)
+
+    return { selected, args }
+  },
+  template: `
+      <ASwitcher v-model="selected" v-bind="args" />`
+})
+
+export const Primary: Story = {
+  render: renderSwitcher,
+  args: {
+    options: [
+      { label: 'Metric', value: 'm' },
+      { label: 'Imperial', value: 'i' }
+    ],
+    label: 'Units'
+  }
+}
+
+export const ThreeOptions: Story = {
+  render: renderSwitcher,
+  args: {
+    options: [
+      { label: 'Map', value: 'map' },
+      { label: 'Tiles', value: 'tile' },
+      { label: 'Table', value: 'table' }
+    ],
+    label: 'View'
+  }
+}
+export const DisabledOption: Story = {
+  render: renderSwitcher,
+  args: {
+    options: [
+      { label: 'Map', value: 'map' },
+      { label: 'Tiles', value: 'tile', disabled: true },
+      { label: 'Table', value: 'table' }
+    ],
+    label: 'View'
+  }
+}
+
+export const DisabledSwitcher: Story = {
+  render: renderSwitcher,
+  args: {
+    ...ThreeOptions.args,
+    disabled: true
+  }
+}
+
+export const IconOptions: Story = {
+  render: renderSwitcher,
+  args: {
+    options: [
+      { label: 'Basic search', value: 'basic', icon: 'Search' },
+      { label: 'AI search', value: 'ai', icon: 'Ai' }
+    ],
+    label: 'Search type'
+  }
+}
+
+export const UsingSlots: Story = {
+  render: args => ({
+    components: { ASwitcher, AIcon },
+    setup() {
+      const selected = ref(args.options[0].value)
+
+      return { selected, args }
     },
     template: `
-        <ASwitcher v-model="selected" :options="options" label="Units" />`
-  })
+      <ASwitcher v-model="selected" v-bind="args">
+        <template #ai><a-icon name="ai" size="sm" class="mr-1"/> AI search</template>
+      </ASwitcher>`
+  }),
+  args: {
+    options: [
+      { label: 'Basic search', value: 'basic' },
+      { label: 'AI search', value: 'ai' }
+    ],
+    label: 'Search type'
+  }
+}
+
+export const RaisedSwitcher: Story = {
+  render: renderSwitcher,
+  args: {
+    ...Primary.args,
+    raised: true
+  }
 }

--- a/src/stories/Switcher.stories.ts
+++ b/src/stories/Switcher.stories.ts
@@ -5,7 +5,12 @@ import ASwitcher from '../components/Switcher.vue'
 
 const meta: Meta<typeof ASwitcher> = {
   component: ASwitcher,
-  title: 'Components/Switcher'
+  title: 'Components/Switcher',
+  decorators: [
+    () => ({
+      template: `<div class="p-10 bg-white"><story/></div>`
+    })
+  ]
 }
 
 export default meta
@@ -21,13 +26,10 @@ export const Primary: Story = {
         { label: 'imperial', value: 'i' }
       ]
       const selected = ref('m')
-      const updateValue = (newValue: string) => {
-        selected.value = newValue
-      }
-      return { selected, options, updateValue }
+
+      return { selected, options }
     },
-    template: `<div class="p-4 bg-white">
-        <ASwitcher :model-value="selected" :options="options" label="Units" @update:modelValue="updateValue" />
-      </div>`
+    template: `
+        <ASwitcher v-model="selected" :options="options" label="Units" />`
   })
 }


### PR DESCRIPTION
no extra functionality over the headless ui's radio group. Just styling plus icon support.

Please let me know how you like this new pattern for storybook docs. Not sold on it yet, but I like the more structured way of describing the stories which I imagine would result in more consistent docs between components.