### PR TITLE
fix(tooltips): correct width inside small relative container

### DIFF
--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -111,7 +111,7 @@ export default defineComponent({
       ref="floating"
       role="tooltip"
       :style="floatingStyles"
-      class="absolute top-0 left-0 max-w-[180px] w-max z-10"
+      class="absolute top-0 left-0 max-w-[180px] min-w-10 w-max z-10"
       :class="isVisible ? 'visible' : 'invisible'">
       <div
         ref="floatingArrow"

--- a/src/components/Tooltip.vue
+++ b/src/components/Tooltip.vue
@@ -111,7 +111,7 @@ export default defineComponent({
       ref="floating"
       role="tooltip"
       :style="floatingStyles"
-      class="absolute top-0 left-0 max-w-[160px] min-w-10 z-10"
+      class="absolute top-0 left-0 max-w-[180px] w-max z-10"
       :class="isVisible ? 'visible' : 'invisible'">
       <div
         ref="floatingArrow"


### PR DESCRIPTION
I made the max-width a big bigger because of extra padding inside the component (l 121), and also set width to max-content so it doesn't wrap too early into multiple lines inside a relatively positioned parent (e.g. in a menu button like in the editor toolbar)