### PR TITLE
feat(sidebar): add className when sidebar is resizing

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -1,5 +1,7 @@
 <script lang="ts">
-import { defineComponent, PropType, ref, Ref } from 'vue'
+import { defineComponent, onBeforeUnmount, PropType, ref, Ref } from 'vue'
+
+export const sidebarResizingClass = 'a-sidebar--resizing'
 
 export default defineComponent({
   name: 'ASidebar',
@@ -28,9 +30,11 @@ export default defineComponent({
   },
   setup(props) {
     const sidebar: Ref<HTMLElement | null> = ref(null)
+    const isResizing = ref(false)
 
     function resize(event: MouseEvent) {
       event.preventDefault() // prevent text selection
+      isResizing.value = true
       document.body.style.cursor = 'col-resize'
       if (sidebar.value) {
         let newWidth: number
@@ -44,6 +48,7 @@ export default defineComponent({
     }
 
     function stopResize() {
+      isResizing.value = false
       document.body.style.cursor = 'auto'
       document.removeEventListener('mousemove', resize, false)
     }
@@ -53,7 +58,11 @@ export default defineComponent({
       document.addEventListener('mouseup', stopResize, false)
     }
 
-    return { initResize, sidebar }
+    onBeforeUnmount(() => {
+      stopResize()
+    })
+
+    return { initResize, sidebar, isResizing }
   },
   computed: {
     borderClass() {
@@ -61,6 +70,9 @@ export default defineComponent({
     },
     resizableClass() {
       return this.side === 'left' ? '-right-1' : '-left-1'
+    },
+    isResizingClass() {
+      return this.isResizing ? sidebarResizingClass : ''
     }
   }
 })
@@ -70,7 +82,7 @@ export default defineComponent({
     :is="as"
     ref="sidebar"
     class="relative min-h-full flex-shrink-0 border-gray bg-white"
-    :class="borderClass">
+    :class="[borderClass, isResizingClass]">
     <div class="flex h-full flex-col items-stretch justify-start">
       <!--
           @slot Use the slot to add children to the sidebar.

--- a/src/components/__tests__/Sidebar.test.ts
+++ b/src/components/__tests__/Sidebar.test.ts
@@ -1,6 +1,6 @@
 import { render, fireEvent } from '@testing-library/vue'
 
-import Sidebar from '../Sidebar.vue'
+import Sidebar, { sidebarResizingClass } from '../Sidebar.vue'
 
 describe('Sidebar.vue', () => {
   describe('when `as` prop is not provided', () => {
@@ -116,6 +116,25 @@ describe('Sidebar.vue', () => {
 
         await fireEvent(document, new MouseEvent('mouseup'))
         expect(window.getComputedStyle(document.body).cursor).toBe('auto')
+      })
+      it(`applies the ${sidebarResizingClass} class`, async () => {
+        const { getByRole } = render(Sidebar, {
+          props: {
+            resizable: true
+          },
+          slots: {
+            default: `sidebar`
+          }
+        })
+        const resizeBar = getByRole('separator')
+
+        await fireEvent(resizeBar, new MouseEvent('mousedown'))
+        await fireEvent(document, new MouseEvent('mousemove', { clientX: 100 }))
+
+        expect(getByRole('complementary')).toHaveClass(sidebarResizingClass)
+
+        await fireEvent(document, new MouseEvent('mouseup'))
+        expect(getByRole('complementary')).not.toHaveClass(sidebarResizingClass)
       })
     })
   })


### PR DESCRIPTION
Resizing a sidebar can cause issues with pointer events received by adjacent or unrelated elements on the page. 

https://github.com/archilogic-com/honeycomb/assets/1694288/fd8bea9a-34a8-4597-b6f5-014db28edabd

This PR adds a predictable class name to the sidebar container during a resize event, which the consumer can use to conditionally disable pointer-events etc. For example:

```css
#my-app:has(.a-sidebar--resizing) iframe {
  pointer-events: none;
}
```
It should be possible to handle this generically in the future, for example by combining both the global cursor setter     (`document.body.style.cursor = 'col-resize'`) and the conditional class.


