### PR TITLE
fix(number-input): support empty initialization

### DIFF
--- a/src/components/NumberInput.vue
+++ b/src/components/NumberInput.vue
@@ -13,7 +13,7 @@ export default defineComponent({
      */
     modelValue: {
       type: Number,
-      default: 0
+      default: undefined
     },
     /**
      * the size of the input field

--- a/src/components/__tests__/NumberInput.test.ts
+++ b/src/components/__tests__/NumberInput.test.ts
@@ -13,6 +13,14 @@ describe('NumberInput.vue', () => {
       expect(getByRole('spinbutton')).toHaveValue(42)
     })
 
+    it('shows placeholder when modelValue is undefined', () => {
+      const { getByRole } = render(NumberInput, {
+        props: { modelValue: undefined, placeholder: 'Test placeholder' }
+      })
+      expect(getByRole('spinbutton')).toHaveAttribute('placeholder', 'Test placeholder')
+      expect(getByRole('spinbutton')).toHaveValue(null)
+    })
+
     it('applies size classes correctly', () => {
       const { getByRole } = render(NumberInput, {
         props: { modelValue: 0, size: 'md' }


### PR DESCRIPTION
Without allowing `undefined` as an initial value, it's not possible to initialize an input with its placeholder-shown