### PR TITLE
fix(AppMenuItem): defer bounding box measurement to next frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [2.19.2-test-fix-context-menu-loop.1](https://github.com/archilogic-com/honeycomb/compare/v2.19.1...v2.19.2-test-fix-context-menu-loop.1) (2025-03-10)
+
+
+### Bug Fixes
+
+* **AppMenuItem:** defer bounding box measurement to next frame ([17efeaf](https://github.com/archilogic-com/honeycomb/commit/17efeaf21bcd9667080efc1343c734c6dcfac8c0))
+
 ## [2.19.1](https://github.com/archilogic-com/honeycomb/compare/v2.19.0...v2.19.1) (2025-01-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@archilogic/honeycomb",
-  "version": "2.19.1",
+  "version": "2.19.2-test-fix-context-menu-loop.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@archilogic/honeycomb",
-      "version": "2.19.1",
+      "version": "2.19.2-test-fix-context-menu-loop.1",
       "dependencies": {
         "@floating-ui/vue": "^1.1.5",
         "@vueuse/core": "^12.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@archilogic/honeycomb",
-  "version": "2.19.1",
+  "version": "2.19.2-test-fix-context-menu-loop.1",
   "publishConfig": {
     "access": "public"
   },

--- a/src/components/AppMenuItem.vue
+++ b/src/components/AppMenuItem.vue
@@ -52,7 +52,10 @@ export default defineComponent({
     const submenu = ref()
     const menuitem = ref()
     const isSubmenuOpen = ref(false)
-    const { right, left, width } = useElementBounding(submenu, { windowScroll: false })
+    const { right, left, width } = useElementBounding(submenu, {
+      windowScroll: false,
+      updateTiming: 'next-frame'
+    })
 
     onMounted(async () => {
       if (props.open) {


### PR DESCRIPTION
This is a quick-fix for the recursive submenu issue. A follow-up will prevent unnecessary recalculations of the submenu dimensions, this change just prevents a page freeze by moving the recalculations into a non-blocking `requestAnimationFrame` loop