### PR TITLE
feat: replace icon name/size props with type-safe icon identifiers

### DIFF
--- a/src/components/AppMenuItem.vue
+++ b/src/components/AppMenuItem.vue
@@ -242,7 +242,7 @@ export default defineComponent({
           "></KeyboardShortcut>
       </div>
       <template v-if="$slots.submenu">
-        <a-icon name="MenuChevronRight" size="other" class="mr-2"></a-icon>
+        <a-icon icon="menu-chevron-right-other" class="mr-2"></a-icon>
         <div
           v-if="isSubmenuOpen"
           ref="submenu"

--- a/src/components/AppMenuMultiButton.vue
+++ b/src/components/AppMenuMultiButton.vue
@@ -53,7 +53,7 @@ export default defineComponent({
         'text-primary': open || pressed,
         'left-0 justify-end pt-[2px]': open
       }">
-      <AIcon name="ChevronDown" size="other" class="mx-[2px]" />
+      <AIcon icon="chevron-down-other" class="mx-[2px]" />
     </button>
   </div>
 </template>

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -42,7 +42,7 @@ export default defineComponent({
       class="flex h-full items-center justify-center rounded-full border border-white bg-whisper text-navy">
       <slot>
         <span v-if="firstLabelLetter" class="capitalize body-sm">{{ firstLabelLetter }}</span>
-        <a-icon v-else name="User" size="md" />
+        <a-icon v-else icon="user-md" />
       </slot>
     </div>
   </div>

--- a/src/components/Button.vue
+++ b/src/components/Button.vue
@@ -2,15 +2,11 @@
 import { computed, defineComponent, PropType } from 'vue'
 import ASpinner from './Spinner.vue'
 import AIcon from './Icon.vue'
-import { type IconIdentifier, type AnyIconName } from './icons/types'
+import { type IconIdentifier } from './icons/types'
 
 export type ButtonVariant = 'primary' | 'subtle' | 'standard'
 
 export type ButtonSize = 'sm' | 'md' | 'lg' | 'auto'
-
-const isIconIdentifier = (str: string): boolean => {
-  return /-(sm|md|lg|other)$/.test(str)
-}
 
 export default defineComponent({
   name: 'AButton',
@@ -46,9 +42,9 @@ export default defineComponent({
       type: String as PropType<ButtonSize>,
       default: 'md'
     },
-    /** IconIdentifier (e.g., "search-sm") or icon name (e.g., "Search") */
+    /** Type-safe icon identifier (e.g., "search-sm", "more-md") */
     icon: {
-      type: [Boolean, String] as PropType<boolean | AnyIconName | IconIdentifier>,
+      type: [Boolean, String] as PropType<boolean | IconIdentifier>,
       default: false
     },
     /**
@@ -85,9 +81,9 @@ export default defineComponent({
     if (props.icon === true) {
       console.warn(
         `Deprecation notice: The recommended usage of the prop "icon" has changed.
-        Provide a string icon name along with size "sm" or "lg" for icon buttons
+        Provide a type-safe icon identifier (e.g. icon="close-sm") for icon buttons
         (instead of the icon markup in the default slot).
-        For flexible dimensions with no extra padding use the size "auto" instead.`
+        For flexible dimensions with no extra padding use a "-other" sized icon.`
       )
     }
 
@@ -102,11 +98,7 @@ export default defineComponent({
       if (typeof props.icon !== 'string' || !props.icon.length) {
         return undefined
       }
-      if (isIconIdentifier(props.icon)) {
-        return props.icon as IconIdentifier
-      }
-      const iconSize = props.size === 'auto' ? 'other' : props.size
-      return `${props.icon}-${iconSize}` as IconIdentifier
+      return props.icon
     })
 
     const ariaLabel = computed(() => {
@@ -140,7 +132,8 @@ export default defineComponent({
       'bg-primary-subtle text-primary': variant !== 'primary' && pressed,
       'text-inherit bg-transparent': variant === 'subtle' && !pressed,
       'bg-athens text-navy': variant === 'standard' && !pressed,
-      'hover:bg-primary-hover active:bg-primary-active': variant === 'primary' && !isDisabled && !pressed,
+      'hover:bg-primary-hover active:bg-primary-active':
+        variant === 'primary' && !isDisabled && !pressed,
       'hover:bg-gray hover:text-navy active:bg-primary-subtle active:text-primary':
         variant !== 'primary' && !isDisabled && !pressed
     }"

--- a/src/components/Checkbox.vue
+++ b/src/components/Checkbox.vue
@@ -80,7 +80,7 @@ export default defineComponent({
     <span
       aria-hidden="true"
       class="custom-mark pointer-events-none absolute hidden p-[3px] text-white">
-      <AIcon :name="mixed ? 'CheckboxIndeterminate' : 'CheckboxCheck'" size="other"></AIcon>
+      <AIcon :icon="mixed ? 'checkbox-indeterminate-other' : 'checkbox-check-other'"></AIcon>
     </span>
     <!--
       @slot Use the default slot to add a label to the checkbox. 

--- a/src/components/Dialog.vue
+++ b/src/components/Dialog.vue
@@ -97,7 +97,7 @@ export default defineComponent({
                 <slot name="title">{{ title }}</slot>
               </HlDialogTitle>
               <AButton
-                icon="Close"
+                icon="close-md"
                 variant="subtle"
                 class="absolute -right-4 top-0 text-stone"
                 label="Close"

--- a/src/components/Disclosure.vue
+++ b/src/components/Disclosure.vue
@@ -52,7 +52,7 @@ export default defineComponent({
       <span class="flex-1 truncate text-left">
         <slot name="title">{{ title }}</slot>
       </span>
-      <AIcon :name="isOpen ? 'Hide' : 'Expand'" size="md" />
+      <AIcon :icon="isOpen ? 'hide-md' : 'expand-md'" />
     </summary>
     <slot name="default" />
   </details>

--- a/src/components/HelperText.vue
+++ b/src/components/HelperText.vue
@@ -32,7 +32,7 @@ export default defineComponent({
 </script>
 <template>
   <span class="flex py-1 body-xs" :class="colorClass">
-    <AIcon v-if="variant === 'error'" class="mr-1" name="Warning" size="sm"></AIcon>
+    <AIcon v-if="variant === 'error'" class="mr-1" icon="warning-sm"></AIcon>
     <slot>{{ content }}</slot>
   </span>
 </template>

--- a/src/components/Icon.vue
+++ b/src/components/Icon.vue
@@ -19,56 +19,33 @@ export type {
 <script setup lang="ts">
 import { computed } from 'vue'
 import icons from './icons'
-import { type IconSize, type IconIdentifier, type AnyIconName } from './icons/types'
+import { type IconSize, type IconIdentifier } from './icons/types'
 
 defineOptions({
   name: 'AIcon'
 })
 
-const props = withDefaults(
-  defineProps<{
-    /**
-     * Type-safe icon identifier in format "name-size" (e.g., "search-sm", "check-md").
-     * This is the recommended way to specify icons as it enforces valid name+size combinations.
-     */
-    icon?: IconIdentifier
-    /**
-     * @deprecated Use `icon` prop instead (e.g., icon="search-sm").
-     * Icon name in PascalCase (e.g. ArrowDown, Warning) or camelCase (e.g. arrowDown, warning).
-     */
-    name?: AnyIconName
-    /**
-     * @deprecated Use `icon` prop instead (e.g., icon="search-sm").
-     * Icon size - used to set width and height on an `svg` element.
-     */
-    size?: IconSize
-  }>(),
-  {
-    icon: undefined,
-    name: undefined,
-    size: 'md'
-  }
-)
+const props = defineProps<{
+  /**
+   * Type-safe icon identifier in format "name-size" (e.g., "search-sm", "check-md").
+   * Enforces valid name+size combinations at the type level.
+   */
+  icon?: IconIdentifier
+}>()
 
 const iconComponent = computed(() => {
-  let size: IconSize
-  let name: string
-
-  if (props.icon) {
-    const lastDash = props.icon.lastIndexOf('-')
-    size = props.icon.slice(lastDash + 1) as IconSize
-    name = props.icon
-      .slice(0, lastDash)
-      .split('-')
-      .map(s => s.charAt(0).toUpperCase() + s.slice(1))
-      .join('')
-  } else if (props.name) {
-    size = props.size
-    name = props.name.charAt(0).toUpperCase() + props.name.slice(1)
-  } else {
-    console.error('a-icon: either "icon" or "name" prop is required')
+  if (!props.icon) {
+    console.error('a-icon: the "icon" prop is required')
     return null
   }
+
+  const lastDash = props.icon.lastIndexOf('-')
+  const size = props.icon.slice(lastDash + 1) as IconSize
+  const name = props.icon
+    .slice(0, lastDash)
+    .split('-')
+    .map(s => s.charAt(0).toUpperCase() + s.slice(1))
+    .join('')
 
   if (icons[size][name]) {
     return icons[size][name]

--- a/src/components/Switcher.vue
+++ b/src/components/Switcher.vue
@@ -10,7 +10,6 @@ import { computed } from 'vue'
 import { RadioGroup, RadioGroupLabel, RadioGroupOption } from '@headlessui/vue'
 import AIcon from './Icon.vue'
 import { type SwitcherOption } from '../types/selection'
-import { type SmIcon, type SmIconId } from './icons/types'
 
 const props = withDefaults(
   defineProps<{
@@ -61,11 +60,7 @@ const model = computed({
         :aria-label="option.icon ? option.label : undefined"
         :title="option.icon ? option.label : undefined">
         <slot :name="String(option.value)">
-          <a-icon
-            v-if="option.icon"
-            :icon="option.icon.endsWith('-sm') ? (option.icon as SmIconId) : undefined"
-            :name="option.icon.endsWith('-sm') ? undefined : (option.icon as SmIcon)"
-            :size="option.icon.endsWith('-sm') ? undefined : 'sm'"></a-icon>
+          <a-icon v-if="option.icon" :icon="option.icon"></a-icon>
           <template v-else>
             {{ option.label }}
           </template>

--- a/src/components/TableCell.vue
+++ b/src/components/TableCell.vue
@@ -73,7 +73,7 @@ export default defineComponent({
           :aria-label="expanded ? 'collapse' : 'expand'"
           class="-ml-1 mr-1"
           @click="toggleCallback">
-          <AIcon size="other" :name="expanded ? 'MenuChevronDown' : 'MenuChevronRight'"></AIcon>
+          <AIcon :icon="expanded ? 'menu-chevron-down-other' : 'menu-chevron-right-other'"></AIcon>
         </button>
       </template>
       <!--

--- a/src/components/Tag.vue
+++ b/src/components/Tag.vue
@@ -77,7 +77,7 @@ export default defineComponent({
       :aria-label="removeLabel"
       :disabled="!!attrs.disabled"
       @click="$emit('remove', $event)">
-      <AIcon name="close" size="sm"></AIcon>
+      <AIcon icon="close-sm"></AIcon>
     </button>
   </div>
 </template>

--- a/src/components/Toast.vue
+++ b/src/components/Toast.vue
@@ -98,7 +98,7 @@ export default defineComponent({
       v-if="dismissible"
       variant="subtle"
       label="Dismiss"
-      icon="Close"
+      icon="close-md"
       class="md:ml-6"
       :class="{
         'text-warsaw': variant === 'default',

--- a/src/components/__tests__/Button.test.ts
+++ b/src/components/__tests__/Button.test.ts
@@ -50,7 +50,7 @@ describe('Button.vue', () => {
   describe('when the "icon" prop and the "label" prop are present', () => {
     it('sets "aria-label" attribute to the value of the "label" prop', () => {
       const { getByRole } = render(Button, {
-        props: { label: 'Label', size: 'md', icon: 'More' }
+        props: { label: 'Label', size: 'md', icon: 'more-md' }
       })
       expect(getByRole('button')).toHaveAttribute('aria-label', 'Label')
     })

--- a/src/components/internal/FloatingArrow.vue
+++ b/src/components/internal/FloatingArrow.vue
@@ -17,6 +17,6 @@ export default defineComponent({
   <div
     class="transition-all duration-300 ease-in-out"
     :class="[float ? 'group-focus-within:grow group-hover:grow' : 'grow-0']">
-    <AIcon name="ChevronDown" size="other" class="ml-auto" />
+    <AIcon icon="chevron-down-other" class="ml-auto" />
   </div>
 </template>

--- a/src/stories/AppMenu/AppMenu.stories.ts
+++ b/src/stories/AppMenu/AppMenu.stories.ts
@@ -129,7 +129,7 @@ export const AllTogether: Story = {
     template: `
         <AAppMenu>
           <template #menu-button="{open, aria}">
-            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="Burger" label="Menu"></AAppMenuButton>
+            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="burger-lg" label="Menu"></AAppMenuButton>
           </template>
           <AAppMenuItem href="https://testing-app.archilogic.com" target="dashboard">Go to dashboard</AAppMenuItem>
           <AAppMenuItem>

--- a/src/stories/AppMenu/AppMenuButton.stories.ts
+++ b/src/stories/AppMenu/AppMenuButton.stories.ts
@@ -57,7 +57,7 @@ export const Primary: Story = {
 export const IconButton: Story = {
   ...Primary,
   args: {
-    icon: 'More',
+    icon: 'more-lg',
     label: 'Actions'
   }
 }
@@ -69,7 +69,7 @@ export const TextAndIcon: Story = {
   ...Primary,
   args: {
     ...Primary.args,
-    default: `Edit <a-icon name="ChevronDown" size="other" />`
+    default: `Edit <a-icon icon="chevron-down-other" />`
   }
 }
 

--- a/src/stories/AppMenu/AppMenuItem.stories.ts
+++ b/src/stories/AppMenu/AppMenuItem.stories.ts
@@ -128,7 +128,7 @@ export const IconIndicator: Story = {
           <AAppMenuItem>Name</AAppMenuItem>
           <AAppMenuItem>
             <template #icon>
-              <AIcon name="ArrowUp" size="sm" />
+              <AIcon icon="arrow-up-sm" />
             </template>
             Date
           </AAppMenuItem>
@@ -288,7 +288,7 @@ export const SubmenuSlot: Story = {
     template: `
         <AAppMenu>
           <template #menu-button="{open, aria}">
-            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="Burger" label="Menu"></AAppMenuButton>
+            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="burger-lg" label="Menu"></AAppMenuButton>
           </template>
           <AAppMenuItem>Go to dashboard</AAppMenuItem>
           <AAppMenuItem>
@@ -332,7 +332,7 @@ export const SubmenuScrolling: Story = {
     template: `
         <AAppMenu>
           <template #menu-button="{open, aria}">
-            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="Burger" label="Menu"></AAppMenuButton>
+            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="burger-lg" label="Menu"></AAppMenuButton>
           </template>
           <AAppMenuItem>
             Labels
@@ -364,7 +364,7 @@ export const SubmenuDisabled: Story = {
     template: `
         <AAppMenu>
           <template #menu-button="{open, aria}">
-            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="Burger" label="Menu"></AAppMenuButton>
+            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="burger-lg" label="Menu"></AAppMenuButton>
           </template>
           <AAppMenuItem>Go to dashboard</AAppMenuItem>
           <AAppMenuItem disabled>
@@ -392,7 +392,7 @@ export const SubmenuNested: Story = {
     template: `
         <AAppMenu>
           <template #menu-button="{open, aria}">
-            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="Burger" label="Menu"></AAppMenuButton>
+            <AAppMenuButton :open="open" v-bind="aria" size="lg" icon="burger-lg" label="Menu"></AAppMenuButton>
           </template>
           <AAppMenuItem>Go to dashboard</AAppMenuItem>
           <AAppMenuItem>
@@ -434,7 +434,7 @@ export const SubmenuRepositioning: Story = {
     template: `
         <AAppMenu align="right" class="ml-auto">
           <template #menu-button="{open}">
-            <AAppMenuButton :open="open" size="lg" icon="Burger" label="Menu"></AAppMenuButton>
+            <AAppMenuButton :open="open" size="lg" icon="burger-lg" label="Menu"></AAppMenuButton>
           </template>
           <AAppMenuItem>Go to dashboard</AAppMenuItem>
           <AAppMenuItem>

--- a/src/stories/Button.mdx
+++ b/src/stories/Button.mdx
@@ -133,10 +133,10 @@ depending on the button's slot content.
 Recommended usage:
 
 ```html
-<a-button size="md" label="Settings" icon="Menu"></a-button>
+<a-button size="md" label="Settings" icon="settings-md"></a-button>
 ```
 
-The icon size will be the same as the value of the button's `size` prop.
+The `icon` prop takes a type-safe identifier in `name-size` format (e.g. `settings-md`).
 It is highly recommended to provide a `label` prop for accessible labelling of the icon button.
 
 <Canvas of={ButtonStories.Icon} />
@@ -185,7 +185,7 @@ and set button size to "auto".
 <a-button label="Button"></a-button>
 <a-button label="Primary Menu">
   Primary
-  <a-icon name="ChevronDown" size="other" />
+  <a-icon icon="chevron-down-other" />
 </a-button>
 ```
 

--- a/src/stories/Button.stories.ts
+++ b/src/stories/Button.stories.ts
@@ -78,7 +78,7 @@ export const StandardWIcon: Story = {
   name: 'standard w/ icon',
   render,
   args: {
-    default: 'Standard <a-icon name="ChevronDown" size="other" />'
+    default: 'Standard <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -87,7 +87,7 @@ export const PrimaryWIcon: Story = {
   render,
   args: {
     variant: 'primary',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />'
+    default: 'Primary <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -96,7 +96,7 @@ export const SubtleWIcon: Story = {
   render,
   args: {
     variant: 'subtle',
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />'
+    default: 'Subtle <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -134,7 +134,7 @@ export const StandardPressedWIcon: Story = {
   render,
   args: {
     pressed: true,
-    default: 'Standard <a-icon name="ChevronDown" size="other" />'
+    default: 'Standard <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -144,7 +144,7 @@ export const PrimaryPressedWIcon: Story = {
   args: {
     variant: 'primary',
     pressed: true,
-    default: 'Primary <a-icon name="ChevronDown" size="other" />'
+    default: 'Primary <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -154,7 +154,7 @@ export const SubtlePressedWIcon: Story = {
   args: {
     variant: 'subtle',
     pressed: true,
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />'
+    default: 'Subtle <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -191,7 +191,7 @@ export const StandardDisabledWIcon: Story = {
   name: 'standard disabled w/ icon',
   render,
   args: {
-    default: 'Standard <a-icon name="ChevronDown" size="other" />',
+    default: 'Standard <a-icon icon="chevron-down-other" />',
     disabled: true
   }
 }
@@ -201,7 +201,7 @@ export const PrimaryDisabledWIcon: Story = {
   render,
   args: {
     variant: 'primary',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />',
+    default: 'Primary <a-icon icon="chevron-down-other" />',
     disabled: true
   }
 }
@@ -211,7 +211,7 @@ export const SubtleDisabledWIcon: Story = {
   render,
   args: {
     variant: 'subtle',
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />',
+    default: 'Subtle <a-icon icon="chevron-down-other" />',
     disabled: true
   }
 }
@@ -249,7 +249,7 @@ export const StandardLoadingWIcon: Story = {
   name: 'standard loading w/ icon',
   render,
   args: {
-    default: 'Standard <a-icon name="ChevronDown" size="other" />',
+    default: 'Standard <a-icon icon="chevron-down-other" />',
     loading: true
   }
 }
@@ -259,7 +259,7 @@ export const PrimaryLoadingWIcon: Story = {
   render,
   args: {
     variant: 'primary',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />',
+    default: 'Primary <a-icon icon="chevron-down-other" />',
     loading: true
   }
 }
@@ -269,7 +269,7 @@ export const SubtleLoadingWIcon: Story = {
   render,
   args: {
     variant: 'subtle',
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />',
+    default: 'Subtle <a-icon icon="chevron-down-other" />',
     loading: true
   }
 }
@@ -309,7 +309,7 @@ export const StandardLargeWIcon: Story = {
   render,
   args: {
     size: 'lg',
-    default: 'Standard <a-icon name="ChevronDown" size="other" />'
+    default: 'Standard <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -319,7 +319,7 @@ export const PrimaryLargeWIcon: Story = {
   args: {
     variant: 'primary',
     size: 'lg',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />'
+    default: 'Primary <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -329,7 +329,7 @@ export const SubtleLargeWIcon: Story = {
   args: {
     variant: 'subtle',
     size: 'lg',
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />'
+    default: 'Subtle <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -372,7 +372,7 @@ export const StandardLargePressedWIcon: Story = {
   args: {
     size: 'lg',
     pressed: true,
-    default: 'Standard <a-icon name="ChevronDown" size="other" />'
+    default: 'Standard <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -383,7 +383,7 @@ export const PrimaryLargePressedWIcon: Story = {
     variant: 'primary',
     size: 'lg',
     pressed: true,
-    default: 'Primary <a-icon name="ChevronDown" size="other" />'
+    default: 'Primary <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -394,7 +394,7 @@ export const SubtleLargePressedWIcon: Story = {
     variant: 'subtle',
     size: 'lg',
     pressed: true,
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />'
+    default: 'Subtle <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -435,7 +435,7 @@ export const StandardLargeDisabledWIcon: Story = {
   render,
   args: {
     size: 'lg',
-    default: 'Standard <a-icon name="ChevronDown" size="other" />',
+    default: 'Standard <a-icon icon="chevron-down-other" />',
     disabled: true
   }
 }
@@ -446,7 +446,7 @@ export const PrimaryLargeDisabledWIcon: Story = {
   args: {
     variant: 'primary',
     size: 'lg',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />',
+    default: 'Primary <a-icon icon="chevron-down-other" />',
     disabled: true
   }
 }
@@ -457,7 +457,7 @@ export const SubtleLargeDisabledWIcon: Story = {
   args: {
     variant: 'subtle',
     size: 'lg',
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />',
+    default: 'Subtle <a-icon icon="chevron-down-other" />',
     disabled: true
   }
 }
@@ -499,7 +499,7 @@ export const StandardLargeLoadingWIcon: Story = {
   render,
   args: {
     size: 'lg',
-    default: 'Standard <a-icon name="ChevronDown" size="other" />',
+    default: 'Standard <a-icon icon="chevron-down-other" />',
     loading: true
   }
 }
@@ -510,7 +510,7 @@ export const PrimaryLargeLoadingWIcon: Story = {
   args: {
     variant: 'primary',
     size: 'lg',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />',
+    default: 'Primary <a-icon icon="chevron-down-other" />',
     loading: true
   }
 }
@@ -521,7 +521,7 @@ export const SubtleLargeLoadingWIcon: Story = {
   args: {
     variant: 'subtle',
     size: 'lg',
-    default: 'Subtle <a-icon name="ChevronDown" size="other" />',
+    default: 'Subtle <a-icon icon="chevron-down-other" />',
     loading: true
   }
 }
@@ -548,7 +548,7 @@ export const Icon: Story = {
   name: 'icon',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-md',
     label: 'Menu'
   }
 }
@@ -558,7 +558,7 @@ export const IconPrimary: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-md',
     label: 'Menu'
   }
 }
@@ -568,7 +568,7 @@ export const IconSubtle: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-md',
     label: 'Menu'
   }
 }
@@ -577,7 +577,7 @@ export const IconLg: Story = {
   name: 'icon lg',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-lg',
     label: 'Menu',
     size: 'lg'
   }
@@ -588,7 +588,7 @@ export const IconLgPrimary: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     label: 'Menu'
   }
@@ -599,7 +599,7 @@ export const IconLgSubtle: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     label: 'Menu'
   }
@@ -609,7 +609,7 @@ export const IconPressed: Story = {
   name: 'icon pressed',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-md',
     pressed: true,
     label: 'Menu'
   }
@@ -620,7 +620,7 @@ export const IconPrimaryPressed: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-md',
     pressed: true,
     label: 'Menu'
   }
@@ -631,7 +631,7 @@ export const IconSubtlePressed: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-md',
     pressed: true,
     label: 'Menu'
   }
@@ -641,7 +641,7 @@ export const IconLgPressed: Story = {
   name: 'icon lg pressed',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     pressed: true,
     label: 'Menu'
@@ -653,7 +653,7 @@ export const IconLgPrimaryPressed: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     pressed: true,
     label: 'Menu'
@@ -665,7 +665,7 @@ export const IconLgSubtlePressed: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     pressed: true,
     label: 'Menu'
@@ -676,7 +676,7 @@ export const IconDisabled: Story = {
   name: 'icon disabled',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-md',
     disabled: true,
     label: 'Menu'
   }
@@ -687,7 +687,7 @@ export const IconPrimaryDisabled: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-md',
     disabled: true,
     label: 'Menu'
   }
@@ -698,7 +698,7 @@ export const IconSubtleDisabled: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-md',
     disabled: true,
     label: 'Menu'
   }
@@ -708,7 +708,7 @@ export const IconLgDisabled: Story = {
   name: 'icon lg disabled',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-lg',
     disabled: true,
     size: 'lg',
     label: 'Menu'
@@ -720,7 +720,7 @@ export const IconLgPrimaryDisabled: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     disabled: true,
     label: 'Menu'
@@ -732,7 +732,7 @@ export const IconLgSubtleDisabled: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     disabled: true,
     label: 'Menu'
@@ -743,7 +743,7 @@ export const IconLoading: Story = {
   name: 'icon loading',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-md',
     loading: true,
     label: 'Menu'
   }
@@ -754,7 +754,7 @@ export const IconPrimaryLoading: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-md',
     loading: true,
     label: 'Menu'
   }
@@ -765,7 +765,7 @@ export const IconSubtleLoading: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-md',
     loading: true,
     label: 'Menu'
   }
@@ -775,7 +775,7 @@ export const IconLgLoading: Story = {
   name: 'icon lg loading',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-lg',
     loading: true,
     size: 'lg',
     label: 'Menu'
@@ -787,7 +787,7 @@ export const IconLgPrimaryLoading: Story = {
   render,
   args: {
     variant: 'primary',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     loading: true,
     label: 'Menu'
@@ -799,7 +799,7 @@ export const IconLgSubtleLoading: Story = {
   render,
   args: {
     variant: 'subtle',
-    icon: 'Burger',
+    icon: 'burger-lg',
     size: 'lg',
     loading: true,
     label: 'Menu'
@@ -810,7 +810,7 @@ export const IconSm: Story = {
   name: 'icon sm',
   render,
   args: {
-    icon: 'Close',
+    icon: 'close-sm',
     size: 'sm'
   }
 }
@@ -819,7 +819,7 @@ export const IconOther: Story = {
   name: 'icon other',
   render,
   args: {
-    icon: 'Padlock',
+    icon: 'padlock-other',
     size: 'auto'
   }
 }
@@ -830,7 +830,7 @@ export const IconAuto: Story = {
   args: {
     label: 'Lock item',
     size: 'auto',
-    default: '<a-icon name="Padlock" size="other" />'
+    default: '<a-icon icon="padlock-other" />'
   }
 }
 
@@ -866,7 +866,7 @@ export const PrimaryWLabelPropAndSlotContent: Story = {
   args: {
     variant: 'primary',
     label: 'Primary Menu',
-    default: 'Primary <a-icon name="ChevronDown" size="other" />'
+    default: 'Primary <a-icon icon="chevron-down-other" />'
   }
 }
 
@@ -913,7 +913,7 @@ export const IconWHref: Story = {
   name: 'icon w/ href',
   render,
   args: {
-    icon: 'Burger',
+    icon: 'burger-lg',
     title: 'Menu',
     size: 'lg',
     href: '/?path=/story/components-button--standard'

--- a/src/stories/HelperText.mdx
+++ b/src/stories/HelperText.mdx
@@ -48,7 +48,7 @@ The following HelperText component is rendered with the `content` prop instead o
 
 ```html
 <a-helper-text>
-  <a-icon size="sm" name="check" />
+  <a-icon icon="check-sm" />
   This is a message with a checkmark
 </a-helper-text>
 ```

--- a/src/stories/HelperText.stories.ts
+++ b/src/stories/HelperText.stories.ts
@@ -59,7 +59,7 @@ export const WCustomMarkup: Story = {
   name: 'w/ custom markup',
   render,
   args: {
-    default: '<a-icon size="sm" name="check" class=" mr-1"/>This is a message with a checkmark',
+    default: '<a-icon icon="check-sm" class=" mr-1"/>This is a message with a checkmark',
     class: 'w-[10rem]'
   }
 }

--- a/src/stories/Icons.mdx
+++ b/src/stories/Icons.mdx
@@ -35,13 +35,16 @@ The `icon` prop accepts kebab-case identifiers like:
 <a-icon icon="burger-sm" />    // Error: 'burger-sm' is not assignable to IconIdentifier
 ```
 
-## Legacy Usage (Deprecated)
+## Migration from `name` / `size`
 
-The `name` and `size` props still work but are deprecated. They don't provide compile-time validation of valid combinations.
+The legacy `name` and `size` props have been **removed**. Use the type-safe `icon` prop instead — combine the (kebab-cased) icon name and size with a dash:
 
 ```html
-<!-- Deprecated: use icon="folder-sm" instead -->
+<!-- Before (removed) -->
 <a-icon size="sm" name="Folder" />
+
+<!-- After -->
+<a-icon icon="folder-sm" />
 ```
 
 ## Icons sm (16x16px)

--- a/src/stories/Icons.stories.ts
+++ b/src/stories/Icons.stories.ts
@@ -32,7 +32,7 @@ const render = (args: IconArgs) => ({
   <div class="grid grid-cols-4">
     <div class="m-4 flex flex-col text-navy" v-for="(icon, name) in icons.${args.size}">
       <div class="flex items-center">
-        <a-icon :size="args.size" :name="name" />
+        <a-icon :icon="getIconId(name)" />
         <span class="ml-3 body-md">{{name}}</span>
         <span v-if="DEPRECATED_ICONS[args.size].includes(name)" class="text-error body-xs-600 mx-1">(deprecated)</span>
       </div>

--- a/src/stories/InputGroup.stories.ts
+++ b/src/stories/InputGroup.stories.ts
@@ -191,11 +191,11 @@ export const LabelAndHelperSlots: Story = {
     },
     template: `
         <AInputGroup v-bind="args" class="w-[300px]">
-          <template #label> <a-icon class="mr-1" name="user" size="sm"/> Label with an icon </template>
+          <template #label> <a-icon class="mr-1" icon="user-sm"/> Label with an icon </template>
           <template #input="{labelledby, describedby}">
             <a-text-input  v-model="myValue" :aria-labelledby="labelledby" :aria-describedby="describedby" />
           </template>
-          <template #helper> Helper needs an icon <a-icon class="ml-1" name="flag" size="sm"/></template>
+          <template #helper> Helper needs an icon <a-icon class="ml-1" icon="flag-sm"/></template>
         </AInputGroup>`
   })
 }

--- a/src/stories/LabelContainer.mdx
+++ b/src/stories/LabelContainer.mdx
@@ -80,13 +80,13 @@ Likewise, the `#default` slot can be used to add custom markup to the value (e.g
 ```html
 <a-label-container label="Width" :value="value">
   <template #label>
-    <a-icon class="mr-1" name="flag" size="sm" />
+    <a-icon class="mr-1" icon="flag-sm" />
     Important key
   </template>
   <template #default>
     <div class="flex">
       1234567890
-      <a-button variant="subtle" icon="copy" size="sm" label="Copy ID"></a-button>
+      <a-button variant="subtle" icon="copy-md" size="sm" label="Copy ID"></a-button>
     </div>
   </template>
 </a-label-container>

--- a/src/stories/LabelContainer.stories.ts
+++ b/src/stories/LabelContainer.stories.ts
@@ -174,7 +174,7 @@ export const LabelSlot: Story = {
   render,
   args: {
     value: 'abcdefg123456',
-    labelSlot: `<a-icon class="mr-1" name="flag" size="sm"/> Important key`,
+    labelSlot: `<a-icon class="mr-1" icon="flag-sm"/> Important key`,
     align: 'col'
   }
 }
@@ -194,7 +194,7 @@ export const DefaultWithButton: Story = {
   render,
   args: {
     ...defaultArgs,
-    default: `<div class="flex items-center overflow-hidden"><span class="truncate">1234567890-098765432-0865434567876543</span><a-button variant="subtle" icon="Copy" label="Copy ID"></a-button></div>`
+    default: `<div class="flex items-center overflow-hidden"><span class="truncate">1234567890-098765432-0865434567876543</span><a-button variant="subtle" icon="copy-md" label="Copy ID"></a-button></div>`
   }
 }
 

--- a/src/stories/Switcher.stories.ts
+++ b/src/stories/Switcher.stories.ts
@@ -109,8 +109,8 @@ export const IconOptions: Story = {
   render: renderSwitcher,
   args: {
     options: [
-      { label: 'Basic search', value: 'basic', icon: 'Search' },
-      { label: 'AI search', value: 'ai', icon: 'Ai' }
+      { label: 'Basic search', value: 'basic', icon: 'search-sm' },
+      { label: 'AI search', value: 'ai', icon: 'ai-sm' }
     ],
     label: 'Search type'
   }
@@ -135,7 +135,7 @@ export const UsingSlots: Story = {
     },
     template: `
       <ASwitcher v-model="selected" v-bind="args">
-        <template #ai><a-icon name="ai" size="sm" class="mr-1"/> AI search</template>
+        <template #ai><a-icon icon="ai-sm" class="mr-1"/> AI search</template>
       </ASwitcher>`
   }),
   args: {

--- a/src/stories/Tooltip.stories.ts
+++ b/src/stories/Tooltip.stories.ts
@@ -40,7 +40,7 @@ const renderTooltip = (args: ComponentProps<TooltipProps>) => ({
   },
   template: `
   <ATooltip v-bind="args" v-slot="slotProps">
-    <a-button v-bind="slotProps" icon="User" size="md"></a-button>
+    <a-button v-bind="slotProps" icon="user-md" size="md"></a-button>
   </ATooltip>`
 })
 

--- a/src/types/selection.ts
+++ b/src/types/selection.ts
@@ -1,5 +1,5 @@
 import { type Color } from '../colors'
-import { type SmIcon, type SmIconId } from '../components/icons/types'
+import { type SmIconId } from '../components/icons/types'
 
 /**
  * Valid value types that can be used as option values.
@@ -71,14 +71,13 @@ export interface OptionGroup<
 
 /**
  * Switcher-specific option with icon support.
- * Icons can be specified as:
- * - SmIconId format: "search-sm", "check-sm" (recommended, type-safe)
- * - SmIcon format: "Search", "Check" (legacy, still supported)
+ * Icons are specified as a type-safe SmIconId (e.g. "search-sm", "check-sm").
+ * Only icons of size "sm" are supported; for other sizes use the option slot.
  *
  * @typeParam V - The type of the option's value (default: string)
  */
 export interface SwitcherOption<V extends OptionValue = string> extends BaseOption<V> {
-  icon?: SmIconId | SmIcon | Uncapitalize<SmIcon>
+  icon?: SmIconId
 }
 
 /**


### PR DESCRIPTION
## What & why

Makes the icon API fully type-safe by removing the non-type-safe icon names ahead of the proper v3.1 release. The old `name`/`size` API didn't enforce valid name+size combinations (e.g. `name="Area"` on an `md` button silently resolved to a non-existent `area-md` at runtime).

## Breaking changes

- **`AIcon`**: removed the deprecated `name` (`AnyIconName`) and `size` props — use `icon` (`IconIdentifier`, e.g. `icon="search-sm"`).
- **`Button`**: `icon` prop now accepts `boolean | IconIdentifier` only (dropped bare names + button-size-derived resolution).
- **`SwitcherOption.icon`**: now `SmIconId` only (dropped `SmIcon` / `Uncapitalize<SmIcon>`).

`AnyIcon` / `AnyIconName` type exports are **retained** (consumers still import them).

## Scope

- Migrated all internal component usages (incl. `Dialog`, `Toast`), the Switcher template, every story + MDX (icon gallery, Button, AppMenu, etc.) and `Button.test.ts` to identifiers.
- Internal sizes preserved (lg buttons → `-lg`, md → `-md`) to minimise Chromatic diffs.

## Verification

- `npm run codecheck` ✅ (vue-tsc + eslint + prettier)
- Unit tests ✅ 225/225 (`npx vitest run --exclude '**/.qa-sandbox/**'`)

## Release / follow-up

- Targets **`beta`**; intentionally a `feat:` (minor, no `BREAKING CHANGE` footer) so it ships as part of **3.1.0** rather than forcing a 4.0.0. Merging to beta will publish `3.1.0-beta.2`.
- Consumer migration needed on upgrade (separate PRs): `dashboard` (`NavigationItem`, `ResourceRow`, `SearchForm`, `RecentSearches`, `router.types`) and `editor` (`HistoryTimelineItem`, `TimelineItem`) type props as `AnyIconName` and pass bare names to `AIcon`/`Button`.
