### PR TITLE
feat(build): drop CJS output and emit flattened ESM type declarations

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,7 +12,15 @@ const config: StorybookConfig = {
   },
 
   async viteFinal(config) {
-    config.plugins = config.plugins || []
+    config.plugins = (config.plugins ?? []).filter(
+      plugin =>
+        !(
+          plugin &&
+          typeof plugin === 'object' &&
+          'name' in plugin &&
+          plugin.name === 'vite:dts'
+        )
+    )
     config.plugins.push(tailwindcss())
     return config
   }

--- a/package.json
+++ b/package.json
@@ -13,38 +13,36 @@
     "tailwind"
   ],
   "type": "module",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/main.js",
-      "require": "./dist/main.cjs"
+      "types": "./dist/main.d.ts",
+      "import": "./dist/main.js"
     },
     "./components": {
-      "types": "./dist/components/index.d.ts",
-      "import": "./dist/components/index.js",
-      "require": "./dist/components/index.cjs"
+      "types": "./dist/components.d.ts",
+      "import": "./dist/components.js"
     },
     "./composables": {
-      "types": "./dist/composables/index.d.ts",
-      "import": "./dist/composables/index.js",
-      "require": "./dist/composables/index.cjs"
+      "types": "./dist/composables.d.ts",
+      "import": "./dist/composables.js"
     },
     "./colors": {
-      "types": "./dist/colors/index.d.ts",
-      "import": "./dist/colors/index.js",
-      "require": "./dist/colors/index.cjs"
+      "types": "./dist/colors.d.ts",
+      "import": "./dist/colors.js"
     },
     "./dist/*": "./dist/*",
     "./tailwind/*": "./tailwind/*",
     "./tailwind": "./tailwind/index.css",
     "./css": "./dist/style.css"
   },
-  "main": "./dist/main.cjs",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/main.js",
+  "types": "./dist/main.d.ts",
   "scripts": {
     "watch": "vite build --watch",
-    "build:component-types": "vue-tsc --emitDeclarationOnly --declaration -p tsconfig.build.json --outDir dist",
-    "build": "vite build && npm run build:component-types",
+    "build": "vite build",
     "prepublishOnly": "npm run build",
     "serve": "vite preview",
     "storybook": "storybook dev -p 6006",

--- a/src/components/Combobox.vue
+++ b/src/components/Combobox.vue
@@ -7,7 +7,7 @@
     ModelValue extends string | string[] = string | string[]
   ">
 import { ref, computed, useAttrs } from 'vue'
-import { Combobox, ComboboxButton, ComboboxInput } from '@headlessui/vue'
+import { Combobox as HlCombobox, ComboboxButton, ComboboxInput } from '@headlessui/vue'
 import ATag from './Tag.vue'
 import AColorCircle from './ColorCircle.vue'
 import OptionsPanel, { type Direction } from './internal/OptionsPanel.vue'
@@ -289,7 +289,7 @@ const isMulti = computed(() => isMultiSelect(model.value))
 </script>
 <template>
   <div ref="container" :class="{ relative: !escapeOverflow }" @focusout="handleBlur">
-    <Combobox v-model="model" :multiple="isMulti" :disabled="!!attrs.disabled">
+    <HlCombobox v-model="model" :multiple="isMulti" :disabled="!!attrs.disabled">
       <!-- @slot  named `#input` slot. Requires ComboboxInput component from headless-ui to work, and optionally ComboboxButton. Slot props: `query<string>`, calculated `displayValue<string>`, and `updateQuery<(value:string)=>void>` callback to be used with text input v-model update event-->
       <slot name="input" :query="query" :display-value="displayValue" :update-query="updateQuery">
         <ComboboxButton
@@ -387,6 +387,6 @@ const isMulti = computed(() => isMultiSelect(model.value))
           </slot>
         </template>
       </OptionsPanel>
-    </Combobox>
+    </HlCombobox>
   </div>
 </template>

--- a/src/components/Listbox.vue
+++ b/src/components/Listbox.vue
@@ -7,7 +7,7 @@
     ModelValue extends string = string
   ">
 import { ref, computed, useAttrs } from 'vue'
-import { Listbox, ListboxButton } from '@headlessui/vue'
+import { Listbox as HlListbox, ListboxButton } from '@headlessui/vue'
 import AColorCircle from './ColorCircle.vue'
 import OptionsPanel, { type Direction } from './internal/OptionsPanel.vue'
 import FloatingArrow from './internal/FloatingArrow.vue'
@@ -113,7 +113,7 @@ const valueOptionColor = computed(() => {
 })
 </script>
 <template>
-  <Listbox v-model="model" as="div" class="group" :class="{ relative: !escapeOverflow }">
+  <HlListbox v-model="model" as="div" class="group" :class="{ relative: !escapeOverflow }">
     <ListboxButton
       ref="listboxButton"
       class="a-text-input flex items-center group-focus-within:a-text-input-focus"
@@ -154,5 +154,5 @@ const valueOptionColor = computed(() => {
       @keyup="handleTab">
       <slot></slot>
     </OptionsPanel>
-  </Listbox>
+  </HlListbox>
 </template>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,10 +15,11 @@ export default defineConfig({
     lib: {
       entry: {
         main: './src/index.ts',
-        'components/index': './src/components/index.ts',
-        'composables/index': './src/composables/index.ts',
-        'colors/index': './src/colors/index.ts'
+        components: './src/components/index.ts',
+        composables: './src/composables/index.ts',
+        colors: './src/colors/index.ts'
       },
+      formats: ['es'],
       cssFileName: 'style'
     },
     rolldownOptions: {
@@ -40,7 +41,8 @@ export default defineConfig({
     vue(),
     tailwindcss(),
     dts({
-      tsconfigPath: './tsconfig.build.json'
+      tsconfigPath: './tsconfig.build.json',
+      rollupTypes: true
     }),
     svgLoader({
       svgo: false


### PR DESCRIPTION
One more change worth grouping into the v3 release:

- drop support for CJS
- rollup the types (addresses packages warnings surfaced by https://arethetypeswrong.github.io/ and https://publint.dev/)