### PR TITLE
fix: migrate TableHeader and AppMenuItem icons to typesafe icon prop

### DIFF
--- a/src/components/AppMenuItem.vue
+++ b/src/components/AppMenuItem.vue
@@ -221,11 +221,7 @@ export default defineComponent({
       class="flex h-8 w-full items-center">
       <div class="ml-2 flex w-4 shrink-0 items-center justify-center">
         <slot name="icon">
-          <a-icon
-            v-if="isSelectable"
-            :class="{ hidden: !selected }"
-            name="Check"
-            size="sm"></a-icon>
+          <a-icon v-if="isSelectable" :class="{ hidden: !selected }" icon="check-sm"></a-icon>
         </slot>
       </div>
       <div class="flex-1 whitespace-nowrap px-2 text-left">

--- a/src/components/TableHeader.vue
+++ b/src/components/TableHeader.vue
@@ -68,8 +68,7 @@ export default defineComponent({
         class="flex h-8 max-h-10 w-full cursor-pointer rounded-sm py-2 pl-4 text-left transition duration-200 ease-in-out body-sm-600 hover:text-newyork focus-visible:focus-shadow">
         <a-icon
           v-if="sortedBy"
-          size="sm"
-          :name="sortedBy === 'asc' ? 'ArrowUp' : 'ArrowDown'"
+          :icon="sortedBy === 'asc' ? 'arrow-up-sm' : 'arrow-down-sm'"
           class="-ml-4"></a-icon>
         <span class="truncate">
           <!--


### PR DESCRIPTION
Two icon props were missed in https://github.com/archilogic-com/honeycomb/pull/332